### PR TITLE
Posts.create fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,20 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install medium
+    $ gem install medium-sdk-ruby
 
 ## Usage
 
 Create a client, then call commands on it.
 
 ```ruby
-require 'medium'
+require 'medium-sdk-ruby'
 
 # If you have a self-issued access token, you can create a new client directly:
 client = Medium::Client.new integration_token: 'example_token'
 
 # Get profile details of the user identified by the access token.
-client.user.me
+client.users.me
 ```
 
 ## Development

--- a/lib/medium/posts.rb
+++ b/lib/medium/posts.rb
@@ -30,8 +30,8 @@ module Medium
     #     }
     #   }
     #   ```
-    def create(opts)
-      @client.post "users/#{@client.users.me['data']['id']}/posts",
+    def create(user, opts)
+      @client.post "users/#{user['data']['id']}/posts",
                    build_request_with(opts)
     end
 


### PR DESCRIPTION
require user object input in 'client.posts.create' action because previous logic was failing to get '@client.users' inside the 'posts.create' block at runtime.
