### PR TITLE
Add support for undocumented API attributes

### DIFF
--- a/lib/medium/posts.rb
+++ b/lib/medium/posts.rb
@@ -53,7 +53,9 @@ module Medium
         hash[:tags] = opts[:tags] if opts.key? :tags
         hash[:canonicalUrl] = opts[:canonical_url] if opts.key? :canonical_url
         hash[:publishStatus] = opts[:publish_status] if opts.key? :publish_status
+        hash[:publishedAt] = opts[:published_at] if opts.key? :published_at
         hash[:license] = opts[:license] if opts.key? :license
+        hash[:notifyFollowers] = opts[:notify_followers] if opts.key? :notify_followers
       end
     end
   end


### PR DESCRIPTION
Per the Medium developers, there are two undocumented API attributes that can be specified if one is uploading a backlog of posts: `publishedAt` and `notifyFollowers`. The `publishedAt` flag takes any date in the past (since scheduling posts isn't yet supported by Medium). The `notifyFollowers` flag is a boolean that disables pinging your followers in case of bulk imports.

More info @ https://github.com/Medium/medium-api-docs/issues/6
