### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/kkirsche/medium-sdk-ruby.svg)](https://travis-ci.org/kkirsche/medium-sdk-ruby) [![Code Climate](https://codeclimate.com/github/kkirsche/medium-sdk-ruby/badges/gpa.svg)](https://codeclimate.com/github/kkirsche/medium-sdk-ruby) [![Test Coverage](https://codeclimate.com/github/kkirsche/medium-sdk-ruby/badges/coverage.svg)](https://codeclimate.com/github/kkirsche/medium-sdk-ruby/coverage)
+[![API Testing](https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg)](https://rapidapi.com/package/Medium/functions?utm_source=MediumGithub&utm_medium=button&utm_content=Vender_GitHub)
 
 # Medium SDK for Ruby
 


### PR DESCRIPTION
Hey there. I added a link in your README to a tool where you can test out Medium API calls in your browser before using your SDK to connect to the API. I've added it to these other SDKs (Telegram, Shopify and LinkedIn) and gotten feedback that it was pretty useful. If anything, let me know what you think and if you have any feedback. I'm part of the team that built this tool and we're always looking to make it better!