### PR TITLE
Change require

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or install it yourself as:
 Create a client, then call commands on it.
 
 ```ruby
-require 'medium-sdk-ruby'
+require 'medium'
 
 # If you have a self-issued access token, you can create a new client directly:
 client = Medium::Client.new integration_token: 'example_token'


### PR DESCRIPTION
require 'medium-sdk-ruby' doesn't work
require 'medium' does. 
